### PR TITLE
【backend】プロンプトをtxtで保存するようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,18 +69,20 @@ pip install --upgrade \
     langchain-core langchain-community langchain-text-splitters \
     chromadb sentence-transformers ollama \
     fastapi \
-    'uvicorn[standard]'
+    'uvicorn[standard]' \
+    watchfiles~=0.24
 ```
 
-| ライブラリ                   | 役割                                              |
-| ---------------------------- | ------------------------------------------------- |
-| **langchain‑core/community** | RAG パイプライン実装                              |
-| **langchain‑text‑splitters** | DDL をテーブル単位に分割                          |
-| **chromadb**                 | ベクトル DB (ローカル)                            |
-| **sentence‑transformers**    | 小型埋め込みモデル呼び出し                        |
-| **ollama**                   | Python からローカル LLM を呼ぶラッパー            |
-| **fastapi**                  | Python で API を開発するための Web フレームワーク |
-| **uvicorn[standard]**        | FastAPI 起動用                                    |
+| ライブラリ                   | 役割                                                                                                      |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **langchain‑core/community** | RAG パイプライン実装                                                                                      |
+| **langchain‑text‑splitters** | DDL をテーブル単位に分割                                                                                  |
+| **chromadb**                 | ベクトル DB (ローカル)                                                                                    |
+| **sentence‑transformers**    | 小型埋め込みモデル呼び出し                                                                                |
+| **ollama**                   | Python からローカル LLM を呼ぶラッパー                                                                    |
+| **fastapi**                  | Python で API を開発するための Web フレームワーク                                                         |
+| **uvicorn[standard]**        | FastAPI 起動用                                                                                            |
+| **watchfiles**               | ァイルやディレクトリの変更を監視し、変更があった場合に処理を実行するための Python ライブラリ(Rust で実装) |
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -113,9 +113,4 @@ def query(q: Query):
     sql_plain = strip_md_fence(raw)
     sql_fmt   = sqlparse.format(sql_plain, strip_comments=True).strip()
 
-    first_token = re.sub(r"^[\s:>\-]+", "", sql_fmt.lstrip()).split()[0].lower()
-    
-    # if first_token not in {"select", "insert", "update", "delete", "with", "create", "alter"}:
-    #     raise HTTPException(status_code=422, detail="LLM did not return valid SQL")
-
     return {"sql": sql_fmt, "ddl_context": ctx}

--- a/app.py
+++ b/app.py
@@ -1,100 +1,121 @@
-# app.py
-# ---------------------------------------------------------------------------
-# 0. 標準 sqlite3 を pysqlite3 にすげ替え（先頭で実施）
-# ---------------------------------------------------------------------------
-import importlib, sys
-import pysqlite3                     # pysqlite3-binary 0.5.2
+# --------------------------------------------------------------------------- #
+# 0.  標準 sqlite3 → pysqlite3 へ差し替え                                     #
+# --------------------------------------------------------------------------- #
+import importlib, sys, os, re, threading
+import pysqlite3                         # pysqlite3-binary 0.5.2
 sys.modules["sqlite3"] = importlib.import_module("pysqlite3")
 
-# ---------------------------------------------------------------------------
-# 1. FastAPI 本体をまず生成
-# ---------------------------------------------------------------------------
-from fastapi import FastAPI
+# --------------------------------------------------------------------------- #
+# 1.  FastAPI インスタンス & CORS                                             #
+# --------------------------------------------------------------------------- #
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
-app = FastAPI(
-    title="Local RAG Server",
-    version="0.1.0",
-)
+app = FastAPI(title="Local RAG Server", version="0.2.0")
 
-# CORS: 8080 のフロントからの POST を許可
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:8080",
-        "http://127.0.0.1:8080",
-    ],
+    allow_origins=["http://localhost:8080", "http://127.0.0.1:8080"],
     allow_methods=["POST"],
     allow_headers=["*"],
 )
 
-# ---------------------------------------------------------------------------
-# 2. 外部ライブラリ
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
+# 2.  外部ライブラリ                                                          #
+# --------------------------------------------------------------------------- #
+from pathlib import Path
+from watchfiles import watch
+
 from pydantic import BaseModel
-from langchain_community.embeddings import OllamaEmbeddings
-from langchain_core.prompts import PromptTemplate
-from langchain_core.runnables import RunnablePassthrough
-from langchain_community.llms import Ollama
 from chromadb import Client
+from langchain_community.embeddings import OllamaEmbeddings
+from langchain_community.llms import Ollama
 import sqlparse, textwrap
 
-# ---------------------------------------------------------------------------
-# 3. RAG 部品の初期化
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
+# 3.  RAG コンポーネント                                                      #
+# --------------------------------------------------------------------------- #
 chroma = Client().get_or_create_collection("ddl")
 emb    = OllamaEmbeddings(model="nomic-embed-text")
 llm    = Ollama(model="llama3:8b", temperature=0)
 
-SYSTEM = """
-You are an expert MySQL engineer.  
-Generate syntactically correct **MySQL 8.0** SQL only.  
-Use the provided schema snippets if relevant.  
-Return only the SQL inside one ```sql``` block.
-"""
+# -- プロンプトファイル設定 -------------------------------------------------- #
+PROMPT_DIR   = Path(__file__).parent / "prompts"
+DEFAULT_PATH = PROMPT_DIR / "system_mysql.txt"
+SYSTEM_PATH  = Path(os.getenv("RAG_SYSTEM_PROMPT", DEFAULT_PATH))
 
-PROMPT = PromptTemplate(
+def load_system_prompt() -> str:
+    if not SYSTEM_PATH.exists():
+        raise FileNotFoundError(f"Prompt file not found: {SYSTEM_PATH}")
+    return SYSTEM_PATH.read_text(encoding="utf-8").strip()
+
+SYSTEM_TEXT = load_system_prompt()  # 初回ロード
+
+# -- watchfiles でホットリロード ------------------------------------------- #
+def _watch_prompt():
+    for _ in watch(str(SYSTEM_PATH)):
+        global SYSTEM_TEXT
+        SYSTEM_TEXT = load_system_prompt()
+        print(f"[Prompt] reloaded → {SYSTEM_PATH}")
+
+threading.Thread(target=_watch_prompt, daemon=True).start()
+
+# -- LangChain 用テンプレート（system だけ動的） ---------------------------- #
+from langchain_core.prompts import PromptTemplate
+
+TEMPLATE = PromptTemplate(
     template=textwrap.dedent("""\
-    {system}
+        {system}
 
-    ### User Request
-    {question}
+        ### User Request
+        {question}
 
-    ### Relevant DDL
-    {context}
+        ### Relevant DDL
+        {context}
     """),
     input_variables=["system", "question", "context"],
 )
 
-# ---------------------------------------------------------------------------
-# 4. I/O スキーマ
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
+# 4.  I/O スキーマ                                                            #
+# --------------------------------------------------------------------------- #
 class Query(BaseModel):
     question: str
 
-# ---------------------------------------------------------------------------
-# 5. Chroma から DDL コンテキストを取得
-# ---------------------------------------------------------------------------
-def retrieve_ctx(q: str, k: int = 4) -> str:
-    qv = emb.embed_query(q)
-    res = chroma.query(
-        query_embeddings=[qv],
-        n_results=k,
-        include=["documents"],
-    )
-    # res = {'ids': [[...]], 'documents': [[...]], 'distances': [[...]]}
-    docs = res["documents"][0]
-    return "\n".join(docs)
+# --------------------------------------------------------------------------- #
+# 5.  DDL コンテキスト取得                                                    #
+# --------------------------------------------------------------------------- #
+def retrieve_ctx(question: str, k: int = 4) -> str:
+    q_emb = emb.embed_query(question)
+    res   = chroma.query(query_embeddings=[q_emb], n_results=k, include=["documents"])
+    return "\n".join(res["documents"][0]) if res["documents"] else ""
 
-# ---------------------------------------------------------------------------
-# 6. エンドポイント
-# ---------------------------------------------------------------------------
+# -- フェンス除去ユーティリティ --------------------------------------------- #
+_fence_start = re.compile(r"^```[\w]*\n?", re.S)
+_fence_end   = re.compile(r"```$", re.S)
+
+def strip_md_fence(text: str) -> str:
+    text = text.strip()
+    if text.startswith("```"):
+        text = _fence_start.sub("", text)
+        text = _fence_end.sub("", text).strip()
+    return text
+
+# --------------------------------------------------------------------------- #
+# 6.  エンドポイント                                                          #
+# --------------------------------------------------------------------------- #
 @app.post("/query")
 def query(q: Query):
     ctx   = retrieve_ctx(q.question)
-    chain = PROMPT | llm
-    raw   = chain.invoke(
-        {"system": SYSTEM, "question": q.question, "context": ctx}
-    )
-    sql_code = sqlparse.format(raw, strip_comments=True).strip()
-    return {"sql": sql_code, "ddl_context": ctx}
+    prompt= TEMPLATE.format(system=SYSTEM_TEXT, question=q.question, context=ctx)
+    raw   = llm.invoke(prompt)
+
+    sql_plain = strip_md_fence(raw)
+    sql_fmt   = sqlparse.format(sql_plain, strip_comments=True).strip()
+
+    first_token = re.sub(r"^[\s:>\-]+", "", sql_fmt.lstrip()).split()[0].lower()
+    
+    # if first_token not in {"select", "insert", "update", "delete", "with", "create", "alter"}:
+    #     raise HTTPException(status_code=422, detail="LLM did not return valid SQL")
+
+    return {"sql": sql_fmt, "ddl_context": ctx}

--- a/prompts/system_mysql.txt
+++ b/prompts/system_mysql.txt
@@ -1,0 +1,15 @@
+You are a senior MySQL 8.0 engineer.
+
+◆ Mission
+Translate the user’s natural-language request into a syntactically correct MySQL 8.0 SQL statement.
+
+◆ Behavioral rules
+1. Use ONLY the tables and columns present in the supplied DDL context.
+2. Do NOT invent schema objects that do not exist.
+3. Produce exactly ONE SQL statement, end it with a semicolon.
+4. Do NOT add comments, explanations, Markdown fences, or any introductory phrases.
+5. Write SQL keywords in UPPERCASE, identifiers in snake_case.
+6. **If you must add a note or explanation, write it in Japanese.**
+
+◆ Output format (MANDATORY)
+Return **only** the SQL statement itself—no headings, labels, or additional text.


### PR DESCRIPTION
## 修正した内容
- `/OLC/prompts/system_mysql.txt`でプロンプトの指示文を追加
- watchfilesを追加してホットリロード追加
- `app.py`でSQL以外は除く処理はコメントアウト
  - プロンプトの指示文で制御をしてはいるがnoteなどのコメントが入る余地あり

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- SQL生成用のシステムプロンプトを外部ファイルから動的に読み込み、サーバー再起動なしで更新可能に。
	- システムプロンプトのホットリロード機能を追加し、リアルタイムでの更新を実現。
- **Improvements**
	- SQL出力のクリーニングとフォーマットを強化し、より正確な結果を提供。
	- コンテキスト取得とプロンプト処理を改善し、クエリ生成の堅牢性を向上。
- **Documentation**
	- READMEを更新し、新たな依存パッケージの追加とその役割を明確化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->