### PR TITLE
Fix bubble overflow on narrow screens

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -29,6 +29,13 @@ main {
   padding: 0.6rem 0.8rem;
   border-radius: 0.7rem;
   line-height: 1.45;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
+.bubble pre {
+  margin: 0;
+  white-space: pre-wrap;
 }
 .user {
   align-self: flex-end;


### PR DESCRIPTION
## Summary
- prevent chat bubble text from overflowing when screen width is small
- wrap lines inside code blocks

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_683f9e3cfea8832fb92d0f4e6b66b81d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - バブル内の長い単語や連続したテキストが自動的に折り返されるようになりました。
  - バブル内のpreformattedテキストも折り返され、横スクロールが発生しにくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->